### PR TITLE
Add sass-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,11 +565,9 @@ CRAN has a [lint](http://cran.r-project.org/web/packages/lint/index.html) packag
 
 ## Sass
 
-[scss-lint](https://github.com/causes/scss-lint) is a Sass/SCSS and CSS linter.
+[sass-lint](https://github.com/sasstools/sass-lint) is a Sass/SCSS linter.
 
-[dftlr/Sasslint](https://github.com/dfltr/Sasslint) is an early Sass linter.
-
-[rstrangh/sasslint](https://rubygems.org/gems/sasslint) is another early Sass linter.
+[scss-lint](https://github.com/brigade/scss-lint) is a Sass/SCSS and CSS linter.
 
 ## Scala
 


### PR DESCRIPTION
Add the new Sass-lint, actively maintained by the Sass Tools team. 

Remove two inactive packages which are also named "Sass lint."

Updated link to the SCSS lint package.